### PR TITLE
Accept webpack builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  lib: require('./emojis'),
-  ordered: require('./ordered'),
+  lib: require('./emojis.json'),
+  ordered: require('./ordered.json'),
   fitzpatrick_scale_modifiers: ["🏻", "🏼", "🏽", "🏾", "🏿"]
 }


### PR DESCRIPTION
It needs to have the file extension to make it work when building with webpack.
json-loader requires the file extension.